### PR TITLE
add unified inference script and documentation

### DIFF
--- a/alert_summary/INFERENCE.md
+++ b/alert_summary/INFERENCE.md
@@ -1,0 +1,272 @@
+# Inference Pipeline
+
+## Overview
+
+This pipeline takes raw network security alerts produced by [Slips](https://github.com/stratosphereips/StratosphereLinuxIPS) and uses a language model to turn them into structured, human-readable reports. It is designed for security researchers and analysts who want to evaluate how well different LLMs — including finetuned small models — perform on real network intrusion data.
+
+### What problem does it solve?
+
+Slips detects threats by correlating low-level network events (port scans, C&C connections, DNS anomalies, etc.) into higher-level *incidents*. Each incident can contain thousands of individual events. Reading those raw events directly is impractical: the signal is buried in repetitive, technical log lines.
+
+This pipeline feeds those events to an LLM and asks it to do two things:
+
+1. **Summarize** — translate the raw evidence into a concise, severity-tagged human report that a SOC analyst can act on quickly.
+2. **Assess risk** — identify the most likely causes of the activity (malicious, legitimate, or misconfiguration) and produce a structured risk assessment with business impact and investigation priority.
+
+### How it fits into the research workflow
+
+There are two ways to get input data into `inference.py`:
+
+**Path A — Research/benchmarking (sampled dataset)**
+```
+Slips alerts (alerts.json)
+        │
+        ▼
+sample_dataset.sh         ← sample incidents across multiple captures into one JSONL
+        │
+        ▼
+inference.py              ← run LLM analysis (summary, risk, or both)
+        │
+        ▼
+output JSON               ← one record per incident with LLM-generated fields
+```
+
+**Path B — Direct analysis (single capture)**
+```
+Slips alerts.json  ──────► inference.py  ──────► output JSON
+```
+
+The raw `alerts.json` files produced by Slips are already in the same JSONL format that `inference.py` expects — one JSON object per line, with `Incident` and `Event` records. You can feed them directly without any sampling step:
+
+```bash
+python3 inference.py \
+  sample_logs/alya_datasets/Malware/CTU-Malware-Capture-Botnet-346-1/2018-04-03_win12-fixed/9/alerts.json \
+  --task risk \
+  --model stratosphere/qwen2.5-1.5b-slips-immune-risk:q8_0 \
+  --base-url http://localhost:11434/v1 \
+  --group-events --verbose
+```
+
+Path B is the natural choice when you have a specific capture you want to analyze. Path A is used when you want a balanced, reproducible dataset drawn from many captures for evaluation or finetuning.
+
+The output JSON is self-contained: each record has the incident metadata plus the LLM analysis. It can be read directly, or fed into the evaluation scripts (`evaluate_summaries.py`, `evaluate_risk.py`) to judge quality with a separate LLM.
+
+### Intended use cases
+
+- **Incident triage** — point the script directly at a Slips `alerts.json` from a live or historical capture and get a structured report immediately
+- **Benchmarking finetuned models** — run the same sampled dataset through multiple models and compare their outputs
+- **Dataset generation** — produce silver-standard analyses from a strong model (GPT-4o) to use as training targets
+
+---
+
+## Limitations
+
+**No resume / checkpointing.** If inference fails mid-run (network error, model crash), the partial output is not saved. For large datasets, consider splitting the JSONL into smaller chunks first.
+
+**No retry logic.** A single failed LLM call causes that incident's analysis to contain an error string rather than real output. Check for `"failed:"` strings in the output if results look incomplete.
+
+**Token limits are your responsibility.** Large incidents can have thousands of events. If the prompt exceeds the model's context window, the API will return an error. Always use `--group-events` with small models (≤3B parameters). For very large incidents even grouped prompts can be long — there is no automatic truncation.
+
+**Finetuned models may ignore prompt structure.** The prompts were designed for instruction-following models. A finetuned model trained on a specific output format may produce outputs that deviate from the expected structure, especially for the `both` task which it was not trained on.
+
+**Timestamps are relative to capture start.** The IDEA format used by Slips anchors `StartTime` to `1970-01-01`, meaning all timestamps reflect time elapsed since the start of the network capture, not wall-clock time. This is expected behavior, not a bug.
+
+**OpenAI API key required even for Ollama.** The `openai` Python library requires a non-empty `OPENAI_API_KEY` environment variable. For local Ollama models, set it to any non-empty string (e.g. `export OPENAI_API_KEY=ollama`).
+
+---
+
+## Files
+
+| File | Role |
+|------|------|
+| `inference.py` | Unified inference script — runs summary and/or risk analysis |
+| `alert_parser_common.py` | Shared parsing and prompt-building utilities |
+
+---
+
+## `alert_parser_common.py` — Shared Utilities
+
+### Data Classes
+
+**`JSONEvent`**
+Represents a single security event from the JSONL file.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | str | Event UUID |
+| `severity` | str | Critical / High / Medium / Low / Info |
+| `start_time` | str | ISO timestamp |
+| `confidence` | float | Detection confidence score |
+| `description` | str | Human-readable event description |
+| `source_ips` | List[str] | Source IP addresses |
+| `source_ports` | List[int] | Source ports |
+| `target_ips` | List[str] | Target IP addresses |
+| `target_ports` | List[int] | Target ports |
+| `note` | Dict | Parsed JSON from the Note field |
+
+**`JSONIncident`**
+Represents an incident (aggregation of correlated events).
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | str | Incident UUID |
+| `source_ips` | List[str] | Source IP addresses |
+| `start_time` | str | ISO timestamp |
+| `correl_ids` | List[str] | Event IDs linked to this incident |
+| `note` | Dict | Contains `timewindow`, `accumulated_threat_level`, `EndTime` |
+
+### Classes
+
+**`AlertJSONParser`**
+Reads a JSONL file and separates `Incident` and `Event` records.
+
+```python
+parser = AlertJSONParser()
+parser.parse_file("datasets/my_dataset_01.jsonl")
+
+# Access all incidents
+for incident in parser.incidents:
+    events = parser.get_incident_events(incident)
+```
+
+### Functions
+
+**`format_time(timestamp, short=False)`**
+Converts an ISO timestamp to a readable string.
+- `short=False` → `"2024-04-05 16:53:07"`
+- `short=True`  → `"16:53"`
+
+**`normalize_pattern(description)`**
+Replaces IPs, ports, and numbers with placeholders for grouping:
+```
+"Horizontal port scan to 443/TCP. 50 unique dst IPs"
+→ "Horizontal port scan to <PORT>/TCP. <NUM> unique dst IPs"
+```
+
+**`group_events_by_pattern(events)`**
+Groups a list of `JSONEvent` objects by their normalized description pattern.
+Returns a list of dicts: `time_range`, `pattern`, `count`, `samples`, `original_desc`.
+
+**`build_evidence_text(events, group=False)`**
+Formats events into a plain-text evidence block for LLM prompts.
+- `group=False` — one line per event: `HH:MM | description`
+- `group=True`  — grouped with counts: `HH:MM | description (12x similar, samples: 1.2.3.4)`
+
+---
+
+## `inference.py` — Unified Inference Script
+
+### Usage
+
+```
+python3 inference.py <input.jsonl> --task {summary|risk|both} [options]
+```
+
+### Arguments
+
+| Argument | Default | Description |
+|----------|---------|-------------|
+| `json_file` | required | Input JSONL file in IDEA format |
+| `--task` | `summary` | Analysis task: `summary`, `risk`, or `both` |
+| `--model` | `gpt-4o-mini` | LLM model name |
+| `--base-url` | `https://api.openai.com/v1` | OpenAI-compatible API endpoint |
+| `--output` / `-o` | auto | Output JSON file path |
+| `--group-events` | off | Group similar events before sending to LLM (reduces tokens) |
+| `--behavior-analysis` | off | Add behavior flow analysis (summary/both tasks only) |
+| `--verbose` / `-v` | off | Print progress and token counts to stderr |
+
+### Auto-named Output Files
+
+| Task | Output filename |
+|------|----------------|
+| `summary` | `{input_base}.llm.{model}.json` |
+| `risk` | `{input_base}.cause_risk.{model}.json` |
+| `both` | `{input_base}.inference.{model}.json` |
+
+### Output Schema
+
+**`--task summary`**
+```json
+[
+  {
+    "incident_id": "54f07359-...",
+    "source_ip": "192.168.1.113",
+    "timewindow": "1",
+    "timeline": "1970-01-01 00:00:16 to 1970-01-01 01:00:16",
+    "threat_level": 15.08,
+    "event_count": 4736,
+    "summary": "...",
+    "behavior_analysis": "..."
+  }
+]
+```
+
+**`--task risk`**
+```json
+[
+  {
+    "incident_id": "54f07359-...",
+    "source_ip": "192.168.1.113",
+    "timewindow": "1",
+    "timeline": "1970-01-01 00:00:16 to 1970-01-01 01:00:16",
+    "threat_level": 15.08,
+    "event_count": 4736,
+    "cause_analysis": "...",
+    "risk_assessment": "..."
+  }
+]
+```
+
+**`--task both`** includes all six analysis fields.
+
+---
+
+## Examples
+
+### OpenAI
+
+```bash
+# Summary
+python3 inference.py datasets/my_dataset_01.jsonl \
+  --task summary --model gpt-4o-mini --group-events --behavior-analysis
+
+# Risk
+python3 inference.py datasets/my_dataset_01.jsonl \
+  --task risk --model gpt-4o-mini --group-events
+```
+
+### Finetuned models via Ollama
+
+```bash
+# Summary — finetuned summarization model
+python3 inference.py datasets/my_dataset_01.jsonl \
+  --task summary \
+  --model stratosphere/qwen2.5-1.5b-slips-immune-summarization:q8_0 \
+  --base-url http://localhost:11434/v1 \
+  --group-events --verbose
+
+# Risk — finetuned risk model
+python3 inference.py datasets/my_dataset_01.jsonl \
+  --task risk \
+  --model stratosphere/qwen2.5-1.5b-slips-immune-risk:q8_0 \
+  --base-url http://localhost:11434/v1 \
+  --group-events --verbose
+```
+
+### Custom output path
+
+```bash
+python3 inference.py datasets/my_dataset_01.jsonl \
+  --task risk \
+  --model stratosphere/qwen2.5-1.5b-slips-immune-risk:q8_0 \
+  --base-url http://localhost:11434/v1 \
+  --output results/risk_finetuned.json
+```
+
+---
+
+## Notes
+
+- `--group-events` is strongly recommended for small models (1.5B) to stay within context limits.
+- `--behavior-analysis` adds a second LLM call per incident; only applies to `summary` and `both` tasks.
+- The API key is read from the `OPENAI_API_KEY` environment variable (or `.env` file). For Ollama, any non-empty value works.

--- a/alert_summary/alert_parser_common.py
+++ b/alert_summary/alert_parser_common.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""
+Shared parsing utilities for Slips IDEA-format JSONL alert files.
+
+Provides JSONEvent, JSONIncident, AlertJSONParser, and helper functions
+used by alert_dag_parser_llm.py, alert_cause_risk_analyzer.py, and inference.py.
+"""
+
+import json
+import re
+import sys
+from collections import defaultdict
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Dict, List
+
+
+@dataclass
+class JSONEvent:
+    """Represents a single Event from the JSONL file."""
+    id: str
+    severity: str
+    start_time: str
+    confidence: float
+    description: str
+    source_ips: List[str]
+    source_ports: List[int]
+    target_ips: List[str]
+    target_ports: List[int]
+    note: Dict[str, Any]
+    raw_json: Dict[str, Any]
+
+    @classmethod
+    def from_json(cls, json_obj: Dict[str, Any]) -> 'JSONEvent':
+        note = {}
+        if 'Note' in json_obj and json_obj['Note']:
+            try:
+                note = json.loads(json_obj['Note'])
+            except Exception:
+                note = {'raw': json_obj['Note']}
+
+        source_ips, source_ports = [], []
+        for src in json_obj.get('Source', []):
+            if 'IP' in src:
+                source_ips.append(src['IP'])
+            if 'Port' in src:
+                source_ports.extend(src['Port'])
+
+        target_ips, target_ports = [], []
+        for tgt in json_obj.get('Target', []):
+            if 'IP' in tgt:
+                target_ips.append(tgt['IP'])
+            if 'Port' in tgt:
+                target_ports.extend(tgt['Port'])
+
+        return cls(
+            id=json_obj.get('ID', ''),
+            severity=json_obj.get('Severity', 'Unknown'),
+            start_time=json_obj.get('StartTime', ''),
+            confidence=json_obj.get('Confidence', 0.0),
+            description=json_obj.get('Description', ''),
+            source_ips=source_ips,
+            source_ports=source_ports,
+            target_ips=target_ips,
+            target_ports=target_ports,
+            note=note,
+            raw_json=json_obj,
+        )
+
+
+@dataclass
+class JSONIncident:
+    """Represents a single Incident from the JSONL file."""
+    id: str
+    source_ips: List[str]
+    start_time: str
+    create_time: str
+    correl_ids: List[str]
+    note: Dict[str, Any]
+    raw_json: Dict[str, Any]
+
+    @classmethod
+    def from_json(cls, json_obj: Dict[str, Any]) -> 'JSONIncident':
+        note = {}
+        if 'Note' in json_obj and json_obj['Note']:
+            try:
+                note = json.loads(json_obj['Note'])
+            except Exception:
+                note = {'raw': json_obj['Note']}
+
+        source_ips = []
+        for src in json_obj.get('Source', []):
+            if 'IP' in src:
+                source_ips.append(src['IP'])
+
+        return cls(
+            id=json_obj.get('ID', ''),
+            source_ips=source_ips,
+            start_time=json_obj.get('StartTime', ''),
+            create_time=json_obj.get('CreateTime', ''),
+            correl_ids=json_obj.get('CorrelID', []),
+            note=note,
+            raw_json=json_obj,
+        )
+
+
+class AlertJSONParser:
+    """Parser for JSONL alert files in IDEA format."""
+
+    def __init__(self):
+        self.incidents: List[JSONIncident] = []
+        self.events: Dict[str, JSONEvent] = {}
+
+    def parse_file(self, filepath: str) -> None:
+        try:
+            with open(filepath, 'r', encoding='utf-8') as f:
+                for line_num, line in enumerate(f, 1):
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        json_obj = json.loads(line)
+                        status = json_obj.get('Status', '')
+                        if status == 'Incident':
+                            self.incidents.append(JSONIncident.from_json(json_obj))
+                        elif status == 'Event':
+                            event = JSONEvent.from_json(json_obj)
+                            self.events[event.id] = event
+                        else:
+                            print(f"Warning: Unknown status '{status}' at line {line_num}", file=sys.stderr)
+                    except json.JSONDecodeError as e:
+                        print(f"Warning: JSON parse error at line {line_num}: {e}", file=sys.stderr)
+                    except Exception as e:
+                        print(f"Warning: Error processing line {line_num}: {e}", file=sys.stderr)
+        except FileNotFoundError:
+            print(f"Error: File '{filepath}' not found.", file=sys.stderr)
+            sys.exit(1)
+        except Exception as e:
+            print(f"Error reading file: {e}", file=sys.stderr)
+            sys.exit(1)
+
+    def get_incident_events(self, incident: JSONIncident) -> List[JSONEvent]:
+        events = []
+        for event_id in incident.correl_ids:
+            if event_id in self.events:
+                events.append(self.events[event_id])
+            else:
+                print(f"Warning: Event {event_id} not found for Incident {incident.id}", file=sys.stderr)
+        return events
+
+
+def format_time(timestamp: str, short: bool = False) -> str:
+    """Format ISO timestamp to readable format."""
+    if not timestamp:
+        return ""
+    try:
+        dt = datetime.fromisoformat(timestamp.replace('Z', '+00:00'))
+        return dt.strftime("%H:%M") if short else dt.strftime("%Y-%m-%d %H:%M:%S")
+    except Exception:
+        return timestamp
+
+
+def normalize_pattern(description: str) -> str:
+    """Normalize variable parts of an event description for grouping."""
+    pattern = description
+    pattern = re.sub(r'\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b', '<IP>', pattern)
+    pattern = re.sub(r'\b\d+/TCP\b', '<PORT>/TCP', pattern, flags=re.IGNORECASE)
+    pattern = re.sub(r'\b\d+/UDP\b', '<PORT>/UDP', pattern, flags=re.IGNORECASE)
+    pattern = re.sub(r'port[s]?:?\s*\d+(-\d+)?', 'port <PORT>', pattern, flags=re.IGNORECASE)
+    pattern = re.sub(r'\b\d+\b', '<NUM>', pattern)
+    return pattern
+
+
+def group_events_by_pattern(events: List[JSONEvent]) -> List[Dict[str, Any]]:
+    """Group events by normalized description pattern. Returns list of group summaries."""
+    groups: Dict[str, List[JSONEvent]] = defaultdict(list)
+    for event in events:
+        groups[normalize_pattern(event.description)].append(event)
+
+    summaries = []
+    for pattern, grp in groups.items():
+        grp.sort(key=lambda e: e.start_time)
+        first_t = format_time(grp[0].start_time, short=True)
+        last_t = format_time(grp[-1].start_time, short=True)
+        time_range = f"{first_t}-{last_t}" if first_t != last_t else first_t
+
+        sample_values: List[str] = []
+        for event in grp[:3]:
+            ips = re.findall(r'\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b', event.description)
+            sample_values.extend(ips[:2])
+            ports = re.findall(r'\b(\d+)/(TCP|UDP)\b', event.description, flags=re.IGNORECASE)
+            sample_values.extend(f"{p[0]}/{p[1]}" for p in ports[:2])
+
+        seen: set = set()
+        unique_samples = [v for v in sample_values if not (v in seen or seen.add(v))]  # type: ignore[func-returns-value]
+
+        summaries.append({
+            'time_range': time_range,
+            'pattern': pattern,
+            'count': len(grp),
+            'samples': unique_samples[:5],
+            'original_desc': grp[0].description,
+        })
+
+    summaries.sort(key=lambda g: (-g['count'], g['time_range']))
+    return summaries
+
+
+def build_evidence_text(events: List[JSONEvent], group: bool = False) -> str:
+    """Build formatted evidence text from events, optionally grouping similar ones."""
+    if group:
+        grouped = group_events_by_pattern(events)
+        lines = []
+        for g in grouped:
+            samples_str = ', '.join(g['samples']) if g['samples'] else 'various'
+            if g['count'] == 1:
+                lines.append(f"{g['time_range']} | {g['original_desc']}")
+            else:
+                lines.append(f"{g['time_range']} | {g['original_desc']} ({g['count']}x similar, samples: {samples_str})")
+        return "\n".join(lines)
+    else:
+        return "\n".join(
+            f"{format_time(e.start_time, short=True)} | {e.description}"
+            for e in events
+        )

--- a/alert_summary/inference.py
+++ b/alert_summary/inference.py
@@ -1,0 +1,539 @@
+#!/usr/bin/env python3
+"""
+Unified Inference Script for Slips Alert Analysis
+
+Accepts a JSONL IDEA-format file and produces LLM-generated analysis.
+Supports three task modes:
+  summary  - generate summary + optional behavior_analysis
+             (output compatible with correlate_incidents.py)
+  risk     - generate cause_analysis + risk_assessment
+             (output compatible with correlate_risks.py)
+  both     - all four analyses in a single pass
+
+Usage:
+    python3 inference.py <input.jsonl> --task summary [options]
+    python3 inference.py <input.jsonl> --task risk [options]
+    python3 inference.py <input.jsonl> --task both [options]
+
+Dependencies:
+    openai, python-dotenv
+    tiktoken (optional, for token counting)
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+from typing import Any, Dict, List, Optional
+
+import openai
+from dotenv import load_dotenv
+
+try:
+    import tiktoken
+    TIKTOKEN_AVAILABLE = True
+except ImportError:
+    TIKTOKEN_AVAILABLE = False
+
+from alert_parser_common import (
+    AlertJSONParser,
+    JSONEvent,
+    JSONIncident,
+    build_evidence_text,
+    format_time,
+    group_events_by_pattern,
+)
+
+load_dotenv()
+
+DEFAULT_MODEL = "gpt-4o-mini"
+DEFAULT_BASE_URL = "https://api.openai.com/v1"
+
+
+class InferenceEngine:
+    """Runs LLM inference for summary and/or risk tasks on IDEA-format incidents."""
+
+    def __init__(self, model: str, base_url: str):
+        self.model = model
+        self.base_url = base_url
+        self.client = openai.OpenAI(
+            api_key=os.getenv("OPENAI_API_KEY"),
+            base_url=base_url,
+            timeout=1200,  # 20 minutes in seconds
+        )
+        self.encoding = None
+        if TIKTOKEN_AVAILABLE:
+            try:
+                self.encoding = tiktoken.encoding_for_model(model)
+            except KeyError:
+                try:
+                    self.encoding = tiktoken.get_encoding("cl100k_base")
+                except Exception:
+                    pass
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def run(self, incident: JSONIncident, events: List[JSONEvent],
+            task: str, group_events: bool = False,
+            behavior_analysis: bool = False,
+            verbose: bool = False) -> Dict[str, Any]:
+        """
+        Run the requested task(s) for a single incident.
+
+        Returns a dict with the fields appropriate to the task:
+          summary  -> summary, behavior_analysis
+          risk     -> cause_analysis, risk_assessment
+          both     -> all four
+        """
+        if not events:
+            msg = f"Incident {incident.id}: No associated events found"
+            result: Dict[str, Any] = {}
+            if task in ('summary', 'both'):
+                result['summary'] = msg
+                result['behavior_analysis'] = None
+            if task in ('risk', 'both'):
+                result['cause_analysis'] = msg
+                result['risk_assessment'] = msg
+            return result
+
+        result = {}
+
+        if task in ('summary', 'both'):
+            result.update(self._run_summary(incident, events, group_events, behavior_analysis, verbose))
+
+        if task in ('risk', 'both'):
+            result.update(self._run_risk(incident, events, group_events, verbose))
+
+        return result
+
+    # ------------------------------------------------------------------
+    # Summary task
+    # ------------------------------------------------------------------
+
+    def _run_summary(self, incident: JSONIncident, events: List[JSONEvent],
+                     group_events: bool, behavior_analysis: bool,
+                     verbose: bool) -> Dict[str, Any]:
+        prompt = self._build_summary_prompt(incident, events, group_events)
+        self._log_query("summary", incident.id, prompt, group_events, len(events), verbose)
+
+        try:
+            summary = self._query_llm(prompt)
+        except Exception as e:
+            print(f"Error querying LLM for summary: {e}", file=sys.stderr)
+            summary = f"Summary failed: {e}"
+
+        behavior = None
+        if behavior_analysis:
+            bprompt = self._build_behavior_prompt(incident, events, group_events)
+            self._log_query("behavior analysis", incident.id, bprompt, group_events, len(events), verbose)
+            try:
+                behavior = self._query_llm(bprompt).replace('AI: ', '').strip()
+            except Exception as e:
+                print(f"Error querying LLM for behavior analysis: {e}", file=sys.stderr)
+                behavior = f"Behavior analysis failed: {e}"
+
+        return {'summary': summary, 'behavior_analysis': behavior}
+
+    def _build_summary_prompt(self, incident: JSONIncident, events: List[JSONEvent],
+                              group_events: bool = False) -> str:
+        source_ip = incident.source_ips[0] if incident.source_ips else "Unknown"
+        timewindow = incident.note.get('timewindow', 'Unknown')
+        threat_level = incident.note.get('accumulated_threat_level', 'Unknown')
+        start_time = format_time(incident.start_time)
+        end_time = format_time(incident.note.get('EndTime', ''))
+
+        if group_events:
+            grouped = group_events_by_pattern(events)
+            event_lines = []
+            for g in grouped:
+                samples_str = ', '.join(g['samples']) if g['samples'] else 'various'
+                if g['count'] == 1:
+                    event_lines.append(f"{g['time_range']} | {g['original_desc']}")
+                else:
+                    event_lines.append(f"{g['time_range']} | {g['original_desc']} ({g['count']}x similar, samples: {samples_str})")
+            events_text = "\n".join(event_lines)
+            event_description = f"GROUPED EVENTS ({len(grouped)} unique patterns from {len(events)} total events)"
+        else:
+            events_text = "\n".join(
+                f"{format_time(e.start_time, short=True)} | {e.description}" for e in events
+            )
+            event_description = "RAW EVENTS (Time | Description)"
+
+        return f"""You are a security analyst. Your task is to translate technical security events into clear, concise, human-readable summaries and assess their severity.
+
+INCIDENT METADATA:
+- Incident ID: {incident.id}
+- Source IP: {source_ip}
+- Timewindow: {timewindow}
+- Accumulated Threat Level: {threat_level}
+- Time Range: {start_time} to {end_time if end_time else 'ongoing'}
+- Total Events: {len(events)}
+
+{event_description}:
+{events_text}
+
+YOUR TASK:
+1. Transform the technical event descriptions into clear, readable summaries using plain language
+2. Group identical or very similar events (e.g., 24 identical connections → one summary line)
+3. Assess the severity of each event/group based on security impact:
+   - CRITICAL: Active exploitation, data exfiltration, confirmed malware C2
+   - HIGH: Scanning, suspicious connections, potential threats
+   - MEDIUM: Anomalous but potentially benign behavior
+   - LOW: Minor issues, likely false positives
+   - INFO: Informational events, normal network behavior
+4. Calculate the overall severity breakdown based on your assessments
+
+OUTPUT FORMAT (match this structure exactly):
+
+============================================================
+Incident: {incident.id}
+Source IP: {source_ip} | Timewindow: {timewindow}
+Timeline: {start_time} to {end_time if end_time else 'ongoing'}
+Threat Level: {threat_level} | Events: {len(events)}
+
+• HH:MM-HH:MM - [Your clear grouped summary] [YOUR_ASSESSED_SEVERITY]
+• HH:MM - [Your clear summary] [YOUR_ASSESSED_SEVERITY]
+
+Total Evidence: {len(events)} events
+Severity breakdown: [Your calculated breakdown, e.g., "High: 5, Medium: 3, Info: 2"]
+
+EXAMPLES OF GOOD SUMMARIZATION WITH SEVERITY ASSESSMENT:
+- "Connection on port 0 from 0.0.0.0:0 to 224.0.0.1:0" → "IGMP multicast traffic to group address [INFO]"
+- "Detected a horizontal port scan to port 443/TCP. 50 unique dst IPs" → "Port scanning 50 hosts on HTTPS port [HIGH]"
+- "Connection to known C2 server 185.29.135.234:443" → "Direct connection to command & control server [CRITICAL]"
+- "Connection without DNS resolution to CDN IP" → "Direct IP connection (likely CDN/API) [LOW]"
+
+RULES:
+- Group identical events into ONE line (don't list the same event 24 times)
+- Use time ranges (HH:MM-HH:MM) when showing grouped events
+- Assess severity based on security impact, not just event type
+- Use severity levels: CRITICAL, HIGH, MEDIUM, LOW, INFO
+- Keep descriptions clear and concise
+- Just output the structured summary - no explanations or meta-commentary
+- Do not include token counts or performance statistics"""
+
+    def _build_behavior_prompt(self, incident: JSONIncident, events: List[JSONEvent],
+                               group_events: bool = False) -> str:
+        source_ip = incident.source_ips[0] if incident.source_ips else "Unknown"
+        timewindow = incident.note.get('timewindow', 'Unknown')
+        threat_level = incident.note.get('accumulated_threat_level', 'Unknown')
+        start_time = format_time(incident.start_time)
+        end_time = format_time(incident.note.get('EndTime', ''))
+        evidence_text = build_evidence_text(events, group=group_events)
+
+        return f"""You are a cybersecurity analyst. Analyze the following network security incident and provide a concise, structured technical explanation of the observed network behavior.
+
+INCIDENT METADATA:
+- Incident ID: {incident.id}
+- Source IP: {source_ip}
+- Timewindow: {timewindow}
+- Accumulated Threat Level: {threat_level}
+- Time Range: {start_time} to {end_time if end_time else 'ongoing'}
+- Total Events: {len(events)}
+
+SECURITY EVIDENCE:
+{evidence_text}
+
+Output Requirements:
+- Respond with ONLY the analysis content
+- Do NOT include any prefixes (like "AI:"), statistics, or metadata
+- Do NOT include token counts, timing information, or performance stats
+- Use this exact structure:
+
+**Source:** {source_ip}
+**Activity:** [Brief activity type]
+**Detected Flows:**
+• [flow description using format: src_ip:port/proto → dest_targets (service)]
+• [additional flows as needed]
+
+**Summary:** [1-2 sentence technical summary of the behavior]
+
+Guidelines:
+- Be succinct (fewer words than raw evidence)
+- Focus only on actual network activity observed
+- Use consistent port/protocol notation (e.g., 80/TCP, 443/TCP)
+- Express flows in compact format when possible
+- Avoid high-level definitions or irrelevant metadata
+- Keep technical depth consistent across all analyses
+- Use bullet points for flows, structured format for sections"""
+
+    # ------------------------------------------------------------------
+    # Risk task
+    # ------------------------------------------------------------------
+
+    def _run_risk(self, incident: JSONIncident, events: List[JSONEvent],
+                  group_events: bool, verbose: bool) -> Dict[str, Any]:
+        cause_prompt = self._build_cause_prompt(incident, events, group_events)
+        self._log_query("cause analysis", incident.id, cause_prompt, group_events, len(events), verbose)
+
+        try:
+            cause_analysis = self._query_llm(cause_prompt).replace('AI: ', '').strip()
+            if '🧠 Stats:' in cause_analysis:
+                cause_analysis = cause_analysis.split('🧠 Stats:')[0].strip()
+        except Exception as e:
+            print(f"Error querying LLM for cause analysis: {e}", file=sys.stderr)
+            cause_analysis = f"Cause analysis failed: {e}"
+
+        risk_prompt = self._build_risk_prompt(incident, events, group_events)
+        self._log_query("risk assessment", incident.id, risk_prompt, group_events, len(events), verbose)
+
+        try:
+            risk_assessment = self._query_llm(risk_prompt).replace('AI: ', '').strip()
+            if '🧠 Stats:' in risk_assessment:
+                risk_assessment = risk_assessment.split('🧠 Stats:')[0].strip()
+        except Exception as e:
+            print(f"Error querying LLM for risk assessment: {e}", file=sys.stderr)
+            risk_assessment = f"Risk assessment failed: {e}"
+
+        return {'cause_analysis': cause_analysis, 'risk_assessment': risk_assessment}
+
+    def _build_cause_prompt(self, incident: JSONIncident, events: List[JSONEvent],
+                            group_events: bool = False) -> str:
+        source_ip = incident.source_ips[0] if incident.source_ips else "Unknown"
+        timewindow = incident.note.get('timewindow', 'Unknown')
+        threat_level = incident.note.get('accumulated_threat_level', 'Unknown')
+        start_time = format_time(incident.start_time)
+        end_time = format_time(incident.note.get('EndTime', ''))
+        evidence_text = build_evidence_text(events, group=group_events)
+
+        return f"""You are a cybersecurity analyst. Analyze the following network security incident and provide a structured analysis of possible causes.
+
+INCIDENT METADATA:
+- Incident ID: {incident.id}
+- Source IP: {source_ip}
+- Timewindow: {timewindow}
+- Accumulated Threat Level: {threat_level}
+- Time Range: {start_time} to {end_time if end_time else 'ongoing'}
+- Total Events: {len(events)}
+
+SECURITY EVIDENCE:
+{evidence_text}
+
+Output Requirements:
+- Respond with ONLY the analysis content
+- Do NOT include any prefixes (like "AI:"), statistics, or metadata
+- Do NOT include token counts, timing information, or performance stats
+- Use this exact structure:
+
+**Possible Causes:**
+
+**1. Malicious Activity:**
+• [Specific attack technique or malicious cause]
+• [Additional malicious possibilities if relevant]
+
+**2. Legitimate Activity:**
+• [Benign operational cause]
+• [Additional legitimate possibilities if relevant]
+
+**3. Misconfigurations:**
+• [Technical misconfigurations that could cause this behavior]
+
+**Conclusion:** [1-2 sentence assessment of most likely cause category with recommendation for further investigation]
+
+Guidelines:
+- Be succinct (fewer words than raw evidence)
+- Focus on relevant causes only (attack techniques, misconfigurations, legitimate operations)
+- Use precise analyst-level language
+- Maintain consistent structure and depth across all analyses
+- Avoid generic definitions or unnecessary context"""
+
+    def _build_risk_prompt(self, incident: JSONIncident, events: List[JSONEvent],
+                           group_events: bool = False) -> str:
+        source_ip = incident.source_ips[0] if incident.source_ips else "Unknown"
+        timewindow = incident.note.get('timewindow', 'Unknown')
+        threat_level = incident.note.get('accumulated_threat_level', 'Unknown')
+        start_time = format_time(incident.start_time)
+        end_time = format_time(incident.note.get('EndTime', ''))
+        evidence_text = build_evidence_text(events, group=group_events)
+
+        return f"""You are a cybersecurity analyst. Analyze the following network security incident and provide a structured risk assessment.
+
+INCIDENT METADATA:
+- Incident ID: {incident.id}
+- Source IP: {source_ip}
+- Timewindow: {timewindow}
+- Accumulated Threat Level: {threat_level}
+- Time Range: {start_time} to {end_time if end_time else 'ongoing'}
+- Total Events: {len(events)}
+
+SECURITY EVIDENCE:
+{evidence_text}
+
+Output Requirements:
+- Respond with ONLY the assessment content
+- Do NOT include any prefixes (like "AI:"), statistics, or metadata
+- Do NOT include token counts, timing information, or performance stats
+- Use this exact structure:
+
+**Risk Level:** [Critical/High/Medium/Low]
+
+**Justification:** [1-2 sentence technical justification for the risk level]
+
+**Business Impact:** [Single clear sentence describing the most relevant business effect]
+
+**Likelihood of Malicious Activity:** [High/Medium/Low] - [Brief rationale]
+
+**Investigation Priority:** [Immediate/High/Medium/Low] - [Brief justification]
+
+Guidelines:
+- Use only the four risk levels: Critical, High, Medium, Low
+- Keep justifications concise and technical
+- Focus business impact on most relevant effect (data access, service disruption, etc.)
+- Use consistent language for likelihood assessments
+- Maintain uniform structure and depth across all assessments
+- Avoid verbose or generic text"""
+
+    # ------------------------------------------------------------------
+    # LLM helpers
+    # ------------------------------------------------------------------
+
+    def _query_llm(self, prompt: str) -> str:
+        messages = [{"role": "user", "content": prompt}]
+        full_reply = ""
+        response = self.client.chat.completions.create(
+            model=self.model,
+            messages=messages,
+            stream=True,
+            stream_options={"include_usage": True},
+        )
+        for chunk in response:
+            if chunk.choices and chunk.choices[0].delta.content:
+                full_reply += chunk.choices[0].delta.content
+        return full_reply.strip()
+
+    def _count_tokens(self, text: str) -> int:
+        if not self.encoding:
+            return 0
+        try:
+            return len(self.encoding.encode(text))
+        except Exception:
+            return 0
+
+    def _log_query(self, label: str, incident_id: str, prompt: str,
+                   group_events: bool, event_count: int, verbose: bool) -> None:
+        if not verbose:
+            return
+        token_count = self._count_tokens(prompt)
+        if token_count > 0:
+            suffix = f", grouped from {event_count} events" if group_events else ""
+            print(f"Querying LLM for {label} of incident {incident_id}... ({token_count} tokens{suffix})",
+                  file=sys.stderr)
+        else:
+            print(f"Querying LLM for {label} of incident {incident_id}...", file=sys.stderr)
+
+
+# ------------------------------------------------------------------
+# Output filename helpers
+# ------------------------------------------------------------------
+
+def _model_name_for_filename(model: str) -> str:
+    return re.sub(r'/.*$', '', model).replace('/', '_')
+
+
+def _default_output(input_file: str, task: str, model: str) -> str:
+    base = input_file.removesuffix('.jsonl') if input_file.endswith('.jsonl') else input_file
+    model_name = _model_name_for_filename(model)
+    if task == 'summary':
+        return f"{base}.llm.{model_name}.json"
+    elif task == 'risk':
+        return f"{base}.cause_risk.{model_name}.json"
+    else:
+        return f"{base}.inference.{model_name}.json"
+
+
+# ------------------------------------------------------------------
+# Main
+# ------------------------------------------------------------------
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description='Unified LLM inference for Slips IDEA-format JSONL alert files'
+    )
+    parser.add_argument('json_file', help='Input JSONL file (IDEA format)')
+    parser.add_argument('--task', choices=['summary', 'risk', 'both'], default='summary',
+                        help='Analysis task to run (default: summary)')
+    parser.add_argument('--model', default=DEFAULT_MODEL,
+                        help=f'LLM model to use (default: {DEFAULT_MODEL})')
+    parser.add_argument('--base-url', default=DEFAULT_BASE_URL,
+                        help=f'LLM API base URL (default: {DEFAULT_BASE_URL})')
+    parser.add_argument('--output', '-o', help='Output file (default: auto-named based on task and model)')
+    parser.add_argument('--incident-id', '-i', help='Analyze specific incident by ID')
+    parser.add_argument('--group-events', action='store_true',
+                        help='Group similar events to reduce token count')
+    parser.add_argument('--behavior-analysis', action='store_true',
+                        help='Generate behavior analysis (summary/both tasks only)')
+    parser.add_argument('--verbose', '-v', action='store_true', help='Verbose output')
+
+    args = parser.parse_args()
+
+    output_file = args.output or _default_output(args.json_file, args.task, args.model)
+
+    if args.verbose:
+        print(f"Input:    {args.json_file}", file=sys.stderr)
+        print(f"Task:     {args.task}", file=sys.stderr)
+        print(f"Model:    {args.model}", file=sys.stderr)
+        print(f"Base URL: {args.base_url}", file=sys.stderr)
+        print(f"Output:   {output_file}", file=sys.stderr)
+
+    alert_parser = AlertJSONParser()
+    alert_parser.parse_file(args.json_file)
+
+    if args.verbose:
+        print(f"Found {len(alert_parser.incidents)} incidents and {len(alert_parser.events)} events",
+              file=sys.stderr)
+
+    incidents_to_process = alert_parser.incidents
+    if args.incident_id:
+        incidents_to_process = [i for i in alert_parser.incidents if i.id == args.incident_id]
+        if not incidents_to_process:
+            print(f"Error: Incident {args.incident_id} not found", file=sys.stderr)
+            sys.exit(1)
+
+    engine = InferenceEngine(args.model, args.base_url)
+    output_data = []
+
+    for incident in incidents_to_process:
+        events = alert_parser.get_incident_events(incident)
+        analysis = engine.run(
+            incident, events,
+            task=args.task,
+            group_events=args.group_events,
+            behavior_analysis=args.behavior_analysis,
+            verbose=args.verbose,
+        )
+
+        source_ip = incident.source_ips[0] if incident.source_ips else "Unknown"
+        timewindow = incident.note.get('timewindow', 'Unknown')
+        threat_level = incident.note.get('accumulated_threat_level', 0)
+        start_time = format_time(incident.start_time)
+        end_time = format_time(incident.note.get('EndTime', ''))
+        timeline = f"{start_time} to {end_time}" if end_time else start_time
+
+        record: Dict[str, Any] = {
+            "incident_id": incident.id,
+            "source_ip": source_ip,
+            "timewindow": str(timewindow),
+            "timeline": timeline,
+            "threat_level": threat_level,
+            "event_count": len(events),
+        }
+        record.update(analysis)
+        output_data.append(record)
+
+    output_json = json.dumps(output_data, indent=2, ensure_ascii=False)
+
+    try:
+        with open(output_file, 'w', encoding='utf-8') as f:
+            f.write(output_json)
+        if args.verbose:
+            print(f"Output written to: {output_file}", file=sys.stderr)
+    except Exception as e:
+        print(f"Error writing output file: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
- inference.py: single script for summary, risk, or both tasks with --task flag; auto-names output to match correlate_incidents/risks consumers; supports OpenAI and Ollama-compatible endpoints
- alert_parser_common.py: shared parsing module extracted from duplicated code across alert_dag_parser_llm.py and alert_cause_risk_analyzer.py
- INFERENCE.md: user-facing documentation covering design rationale, both usage paths (direct alerts.json and sampled datasets), CLI reference, output schemas, and limitations

